### PR TITLE
Switched test project framework to .net core for use on non-windows p…

### DIFF
--- a/test/HttpBatchHandler.Tests/BatchMiddlewareTests.cs
+++ b/test/HttpBatchHandler.Tests/BatchMiddlewareTests.cs
@@ -161,8 +161,7 @@ namespace HttpBatchHandler.Tests
             var requestFeature = new HttpRequestFeature {Path = "/api/batch"};
             requestFeature.Headers.Add(HeaderNames.ContentType,
                 "multipart/mixed; boundary=\"batch_357647d1-a6b5-4e6a-aa73-edfc88d8866e\"");
-            requestFeature.Body = GetType().Assembly
-                .GetManifestResourceStream(typeof(MultipartParserTests), "MultipartRequest.txt");
+            requestFeature.Body = TestUtilities.GetNormalizedContentStream("MultipartRequest.txt");
             var responseFeature = new HttpResponseFeature();
             var mockedEvents = new ThrowExceptionEventHandler();
             using (responseFeature.Body = new MemoryStream())
@@ -187,8 +186,7 @@ namespace HttpBatchHandler.Tests
             var requestFeature = new HttpRequestFeature {Path = "/api/batch"};
             requestFeature.Headers.Add(HeaderNames.ContentType,
                 "multipart/mixed; boundary=\"batch_357647d1-a6b5-4e6a-aa73-edfc88d8866e\"");
-            requestFeature.Body = GetType().Assembly
-                .GetManifestResourceStream(typeof(MultipartParserTests), "MultipartRequest.txt");
+            requestFeature.Body = TestUtilities.GetNormalizedContentStream("MultipartRequest.txt");
             var responseFeature = new HttpResponseFeature();
             var mockedEvents = new MockedBatchEventHandler();
             using (responseFeature.Body = new MemoryStream())
@@ -233,8 +231,7 @@ namespace HttpBatchHandler.Tests
             var requestFeature = new HttpRequestFeature {Path = "/api/batch"};
             requestFeature.Headers.Add(HeaderNames.ContentType,
                 "multipart/mixed; boundary=\"batch_357647d1-a6b5-4e6a-aa73-edfc88d8866e\"");
-            requestFeature.Body = GetType().Assembly
-                .GetManifestResourceStream(typeof(MultipartParserTests), "MultipartRequest.txt");
+            requestFeature.Body = TestUtilities.GetNormalizedContentStream("MultipartRequest.txt");
             var responseFeature = new HttpResponseFeature();
             var mockedEvents = new MockedBatchEventHandler();
             using (responseFeature.Body = new MemoryStream())
@@ -245,8 +242,7 @@ namespace HttpBatchHandler.Tests
                     CreateThirdResponse(),
                     CreateFourthResponse()).ConfigureAwait(false);
                 Assert.Equal(StatusCodes.Status200OK, responseFeature.StatusCode);
-                var refText = await GetType().Assembly
-                    .GetManifestResourceStream(typeof(MultipartParserTests), "MultipartResponse.txt")
+                var refText = await TestUtilities.GetNormalizedContentStream("MultipartResponse.txt")
                     .ReadAsStringAsync().ConfigureAwait(false);
                 responseFeature.Body.Position = 0;
                 var outputText = await responseFeature.Body.ReadAsStringAsync().ConfigureAwait(false);

--- a/test/HttpBatchHandler.Tests/HttpBatchHandler.Tests.csproj
+++ b/test/HttpBatchHandler.Tests/HttpBatchHandler.Tests.csproj
@@ -1,28 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="MultipartRequestPathBase.txt" />
     <EmbeddedResource Include="MultipartRequest.txt" />
     <EmbeddedResource Include="MultipartResponse.txt" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
@@ -32,9 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\HttpBatchHandler.Website\HttpBatchHandler.Website.csproj" />
   </ItemGroup>
-
 </Project>

--- a/test/HttpBatchHandler.Tests/MultipartContentTests.cs
+++ b/test/HttpBatchHandler.Tests/MultipartContentTests.cs
@@ -40,8 +40,7 @@ namespace HttpBatchHandler.Tests
             }
             string input;
 
-            using (var refTextStream = GetType().Assembly
-                .GetManifestResourceStream(typeof(MultipartParserTests), "MultipartRequest.txt"))
+            using (var refTextStream = TestUtilities.GetNormalizedContentStream("MultipartRequest.txt"))
             {
                 Assert.NotNull(refTextStream);
                 input = await refTextStream.ReadAsStringAsync().ConfigureAwait(false);

--- a/test/HttpBatchHandler.Tests/MultipartParserTests.cs
+++ b/test/HttpBatchHandler.Tests/MultipartParserTests.cs
@@ -18,7 +18,7 @@ namespace HttpBatchHandler.Tests
         public async Task Parse(string path, string file)
         {
             var reader = new MultipartReader("batch_357647d1-a6b5-4e6a-aa73-edfc88d8866e",
-                GetType().Assembly.GetManifestResourceStream(typeof(MultipartParserTests), file));
+                TestUtilities.GetNormalizedContentStream(file));
             var sections = new List<HttpApplicationRequestSection>();
 
             HttpApplicationRequestSection section;

--- a/test/HttpBatchHandler.Tests/MultipartWriterTests.cs
+++ b/test/HttpBatchHandler.Tests/MultipartWriterTests.cs
@@ -36,8 +36,7 @@ namespace HttpBatchHandler.Tests
             }
             string input;
 
-            using (var refTextStream = GetType().Assembly
-                .GetManifestResourceStream(typeof(MultipartParserTests), "MultipartResponse.txt"))
+            using (var refTextStream = TestUtilities.GetNormalizedContentStream("MultipartResponse.txt"))
             {
                 Assert.NotNull(refTextStream);
                 input = await refTextStream.ReadAsStringAsync().ConfigureAwait(false);
@@ -50,7 +49,7 @@ namespace HttpBatchHandler.Tests
         public async Task ParseExample()
         {
             var reader = new MultipartReader("61cfbe41-7ea6-4771-b1c5-b43564208ee5",
-                GetType().Assembly.GetManifestResourceStream(typeof(MultipartParserTests), "MultipartResponse.txt"));
+                TestUtilities.GetNormalizedContentStream("MultipartResponse.txt"));
             var sections = new List<HttpApplicationResponseSection>();
 
             HttpApplicationResponseSection section;

--- a/test/HttpBatchHandler.Tests/TestUtilities.cs
+++ b/test/HttpBatchHandler.Tests/TestUtilities.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+namespace HttpBatchHandler.Tests
+{
+    public static class TestUtilities
+    {
+        public static Stream GetNormalizedContentStream(string file)
+        {
+            var originalStream = typeof(TestUtilities).Assembly.GetManifestResourceStream(typeof(MultipartParserTests), file);
+            
+            // It's possible that git (or other tools) will automatically convert crlf line endings from the 
+            // text files to lf on linux/mac machines.  The Multipart spec is looking for crlf and thus line endings
+            // of lf are invalid.  Therefore, for these tests to be valid we need to make sure all line endings are
+            // crlf and not just lf.
+            var reader = new StreamReader(originalStream);
+            var content = reader.ReadToEnd();
+
+            content = content.Replace("\r\n", "\n").Replace("\n", "\r\n");
+            
+            var normalizedStream = new MemoryStream();
+            var writer = new StreamWriter(normalizedStream);
+            writer.Write(content);
+            writer.Flush();
+            normalizedStream.Position = 0;
+
+            return normalizedStream;
+        }
+    }
+}

--- a/test/HttpBatchHandler.Website/HttpBatchHandler.Website.csproj
+++ b/test/HttpBatchHandler.Website/HttpBatchHandler.Website.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
…latforms.

Also had to modify how the way the test project loaded the text files for testing to make sure a non-windows OS does not cause the line endings to be read outside of the HTTP spec of CRLF.