### PR TITLE
Set Success StatusCode too

### DIFF
--- a/src/HttpBatchHandler/BatchMiddleware.cs
+++ b/src/HttpBatchHandler/BatchMiddleware.cs
@@ -156,10 +156,9 @@ namespace HttpBatchHandler
                         IsAborted = abort,
                         Response = httpContext.Response
                     };
-                    if (endContext.Exception != null)
-                    {
-                        endContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
-                    }
+                    endContext.Response.StatusCode = endContext.Exception != null
+                        ? StatusCodes.Status500InternalServerError
+                        : StatusCodes.Status200OK;
 
                     await _options.Events.BatchEndAsync(endContext, cancellationToken).ConfigureAwait(false);
                     if (!endContext.IsHandled)

--- a/src/HttpBatchHandler/HttpBatchHandler.csproj
+++ b/src/HttpBatchHandler/HttpBatchHandler.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.3.1</Version>
-    <AssemblyVersion>0.3.1.0</AssemblyVersion>
-    <FileVersion>0.3.1.0</FileVersion>
+    <Version>0.3.2</Version>
+    <AssemblyVersion>0.3.2.0</AssemblyVersion>
+    <FileVersion>0.3.2.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>HttpBatchHandler for ASP.NET Core 2.0 Contributors 2018</Copyright>
     <PackageId>HttpBatchHandler</PackageId>


### PR DESCRIPTION
The new "inprocess" Mode in ASP.NET Core 2.1 apparently defaults to 500 as the default status code, so we need to set the result in success too.