### PR TITLE
Retaining https scheme for child requests if batch is https

### DIFF
--- a/src/HttpBatchHandler/BatchMiddleware.cs
+++ b/src/HttpBatchHandler/BatchMiddleware.cs
@@ -86,7 +86,7 @@ namespace HttpBatchHandler
                 {
                     HttpApplicationRequestSection section;
                     while ((section = await reader
-                               .ReadNextHttpApplicationRequestSectionAsync(pathBase, cancellationToken)
+                               .ReadNextHttpApplicationRequestSectionAsync(pathBase, httpContext.Request.IsHttps, cancellationToken)
                                .ConfigureAwait(false)) != null)
                     {
                         httpContext.RequestAborted.ThrowIfCancellationRequested();

--- a/src/HttpBatchHandler/Multipart/HttpApplicationRequestSectionExtensions.cs
+++ b/src/HttpBatchHandler/Multipart/HttpApplicationRequestSectionExtensions.cs
@@ -16,7 +16,7 @@ namespace HttpBatchHandler.Multipart
         private static readonly char[] SpaceArray = {' '};
 
         public static async Task<HttpApplicationRequestSection> ReadNextHttpApplicationRequestSectionAsync(
-            this MultipartReader reader, PathString pathBase = default, CancellationToken cancellationToken = default)
+            this MultipartReader reader, PathString pathBase = default, bool isHttps = false, CancellationToken cancellationToken = default)
         {
             var section = await reader.ReadNextSectionAsync(cancellationToken).ConfigureAwait(false);
             if (section == null)
@@ -53,7 +53,7 @@ namespace HttpBatchHandler.Multipart
                 throw new InvalidDataException("No Host Header");
             }
 
-            var uri = BuildUri(hostHeader, requestLineParts[1]);
+            var uri = BuildUri(isHttps, hostHeader, requestLineParts[1]);
             var fullPath = PathString.FromUriComponent(uri);
             var feature = new HttpRequestFeature
             {
@@ -81,7 +81,7 @@ namespace HttpBatchHandler.Multipart
             };
         }
 
-        private static Uri BuildUri(StringValues hostHeader, string pathAndQuery)
+        private static Uri BuildUri(bool isHttps, StringValues hostHeader, string pathAndQuery)
         {
             if (hostHeader.Count != 1)
             {
@@ -94,7 +94,8 @@ namespace HttpBatchHandler.Multipart
                 return null;
             }
 
-            var fullUri = $"http://{hostString.ToUriComponent()}{pathAndQuery}";
+            var scheme = isHttps ? "https" : "http";
+            var fullUri = $"{scheme}://{hostString.ToUriComponent()}{pathAndQuery}";
             var uri = new Uri(fullUri);
             return uri;
         }


### PR DESCRIPTION
We were trying to use your project to add batch request handling to our .net core 2 API. We were having some issues though with it returning 200 on the batch but all of the sub requests were returning 403. It turns out that this was because our batch request was over https but it was transforming the sub requests into http (which we don't allow). After looking through your code, I saw that you are hard coding the sub requests to http.

I have tweaked your code to pass through whether the batch request is https so that the sub requests match the batch request scheme. 

Hopefully you find it useful to bring in to the main project.